### PR TITLE
commiting a fix already included in later versions of Context

### DIFF
--- a/sites/all/modules/contrib/context/context.core.inc
+++ b/sites/all/modules/contrib/context/context.core.inc
@@ -106,7 +106,8 @@ function context_entity_prepare_view($prepare, $entity_type) {
   if ($entity_type === 'taxonomy_term' && count($prepare) === 1) {
     $term = reset($prepare);
     $menu = menu_get_object('taxonomy_term', 2);
-    if ($term->tid == $menu->tid && $plugin = context_get_plugin('condition', 'taxonomy_term')) {
+    // adding the $menu condition as in: https://drupal.org/node/2099717
+    if ($menu && $term->tid == $menu->tid && $plugin = context_get_plugin('condition', 'taxonomy_term')) {
       $plugin->execute($term, 'view');
     }
   }


### PR DESCRIPTION
I was getting the following message when trying to import 
Notice: Trying to get property of non-object in context_entity_prepare_view() (line 109 of /....sites/all/modules/context/context.core.inc).

Issue is resolved in 
https://drupal.org/node/2099717 in later versions of the context module
